### PR TITLE
Port to mlg, adapt to SProp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@ Makefile.coq.conf
 *.glob
 *.vo
 *.vio
+*.a
 *.cmi
 *.cmx
 *.cmxs
+*.cmxa
 *.o
 run.ml
 run.mli
 result
+staltac.ml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
 
   # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq/tarball/d6a5375460
+  - env: COQ=https://github.com/coq/coq-on-cachix/tarball/master
 
   # Test opam package
   - language: minimal
@@ -39,12 +39,7 @@ matrix:
         export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
         set -ex
         sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
-        opam install -y -j ${NJOBS} .
+        opam install -v -y -j ${NJOBS} .
         "
     - docker stop COQ  # optional
     - echo -en 'travis_fold:end:script\\r'
-
-  allow_failures:
-  - services: docker
-  # opam tests are relying on a possibly more recent version
-  # than the Nix test which uses a pinned commit

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 all: Makefile.coq
-	+make -f Makefile.coq all
+	+$(MAKE) -f Makefile.coq all
 
 clean: Makefile.coq
-	+make -f Makefile.coq clean
-	rm -f Makefile.coq
+	+$(MAKE) -f Makefile.coq cleanall
+	rm -f Makefile.coq Makefile.coq.conf
 
-Makefile.coq: Make
-	$(COQBIN)coq_makefile -f Make -o Makefile.coq
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-Make: ;
+_CoqProject Makefile: ;
 
 %: Makefile.coq
-	+make -f Makefile.coq $@
+	+$(MAKE) -f Makefile.coq $@
 
 .PHONY: all clean

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,7 +1,7 @@
 post-all:: extraction/stalmarck
 
 extraction/stalmarck: Extract.vo
-	$(MAKE) -C extraction all
+	+$(MAKE) -C extraction all
 
 test: extraction/stalmarck
 	@echo '***** test: checking the tautology ztwaalf1_be *****'
@@ -9,6 +9,6 @@ test: extraction/stalmarck
 	@echo '******************** End of test ***********************'
 
 clean::
-	$(MAKE) -C extraction clean
+	+$(MAKE) -C extraction clean
 
 .PHONY: test

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -1,0 +1,14 @@
+post-all:: extraction/stalmarck
+
+extraction/stalmarck: Extract.vo
+	$(MAKE) -C extraction all
+
+test: extraction/stalmarck
+	@echo '***** test: checking the tautology ztwaalf1_be *****'
+	extraction/stalmarck 1 extraction/ztwaalf1_be
+	@echo '******************** End of test ***********************'
+
+clean::
+	$(MAKE) -C extraction clean
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 [![Gitter][gitter-shield]][gitter-link]
 [![DOI][doi-shield]][doi-link]
 
-[doi-shield]: https://zenodo.org/badge/DOI/10.1007/3-540-44659-1_24.svg
-[doi-link]: https://doi.org/10.1007/3-540-44659-1_24
-
 [travis-shield]: https://travis-ci.com/coq-community/stalmarck.svg?branch=master
 [travis-link]: https://travis-ci.com/coq-community/stalmarck/builds
 
@@ -21,7 +18,10 @@
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
 
-A two-level approach to prove tautologies using Stålmarck's algorithm.
+[doi-shield]: https://zenodo.org/badge/DOI/10.1007/3-540-44659-1_24.svg
+[doi-link]: https://doi.org/10.1007/3-540-44659-1_24
+
+A two-level approach to prove tautologies using Stålmarck's algorithm in Coq.
 
 
 More details about the project can be found in the paper

--- a/StalTac.v
+++ b/StalTac.v
@@ -28,6 +28,6 @@ Require Export normalize.
 Require Export algoTrace.
 Require Export refl.
 
-Declare ML Module "staltac".
+Declare ML Module "staltac_plugin".
 
 Ltac staltac := intros; repeat pop_prop; stalt.

--- a/_CoqProject
+++ b/_CoqProject
@@ -42,12 +42,6 @@ triplet.v
 unionState.v
 wfArray.v
 
-staltac.ml4
-
--extra extraction/stalmarck Extract.vo
-       "$(MAKE) -C extraction all"
--extra-phony test extraction/stalmarck "@echo '***** test: checking the tautology ztwaalf1_be *****'
-	extraction/stalmarck 1 extraction/ztwaalf1_be
-	@echo '******************** End of test ***********************'"
--extra-phony clean "" "$(MAKE) -C extraction clean"
--extra-phony all test ""
+staltac.mlg
+staltac_plugin.mlpack
+staltac_lib.ml

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ pkgs.stdenv.mkDerivation {
 
   name = "stalmarck";
 
-  buildInputs = with coq.ocamlPackages; [ ocaml findlib camlp5 ]
+  buildInputs = with coq.ocamlPackages; [ ocaml findlib ]
     ++ pkgs.lib.optionals shell [ merlin ocp-indent ocp-index ];
 
   propagatedBuildInputs = [

--- a/extraction/.gitignore
+++ b/extraction/.gitignore
@@ -3,4 +3,4 @@ lexer.ml
 parser.ml
 parser.mli
 stal.ml
-
+stal.mli

--- a/extraction/Makefile
+++ b/extraction/Makefile
@@ -53,6 +53,7 @@ clean :
 	rm -f *.o *.cmx *.cmi \
 	$(PROG) \
 	stal.ml \
+	stal.mli \
 	lexer.ml \
 	parser.ml \
 	parser.mli

--- a/meta.yml
+++ b/meta.yml
@@ -1,9 +1,13 @@
 ---
 fullname: Stalmarck
 shortname: stalmarck
+organization: coq-community
+community: true
+
+synopsis: Proof of Stålmarck's algorithm in Coq
 
 description: |
-  A two-level approach to prove tautologies using Stålmarck's algorithm.
+  A two-level approach to prove tautologies using Stålmarck's algorithm in Coq.
 
 paper:
   doi: 10.1007/3-540-44659-1_24
@@ -31,7 +35,7 @@ supported_coq_versions:
   opam: '{= "dev" }'
 
 tested_coq_versions:
-- version_or_url: https://github.com/coq/coq/tarball/d6a5375460
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
 
 tested_coq_opam_version: dev
 

--- a/opam
+++ b/opam
@@ -1,15 +1,22 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/coq-community/stalmarck"
-dev-repo: "https://github.com/coq-community/stalmarck.git"
+dev-repo: "git+https://github.com/coq-community/stalmarck.git"
 bug-reports: "https://github.com/coq-community/stalmarck/issues"
 license: "LGPL-2.1-or-later"
+
+synopsis: "Proof of Stålmarck's algorithm in Coq"
+description: """
+A two-level approach to prove tautologies using Stålmarck's algorithm in Coq.
+"""
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Stalmarck"]
+flags: light-uninstall
 depends: [
+  "ocaml"
   "coq" {= "dev" }
 ]
 

--- a/staltac.mlg
+++ b/staltac.mlg
@@ -1,0 +1,11 @@
+DECLARE PLUGIN "staltac_plugin"
+
+{
+
+open Ltac_plugin
+open Staltac_lib
+
+}
+
+TACTIC EXTEND _stalt_ | [ "stalt" ] -> { Proofview.V82.tactic stalt_run } END
+TACTIC EXTEND _pop_prop_ | [ "pop_prop" ] -> { Proofview.V82.tactic pop_prop_run } END

--- a/staltac_lib.ml
+++ b/staltac_lib.ml
@@ -1159,7 +1159,7 @@ let convertConcl sigma cl =
     | App (c,[|t1; t2|]) when EConstr.eq_constr sigma c (Lazy.force coq_iff) ->
              (Node (Eq, (inspect t1),(inspect t2)))
 (* Impl *)
-    | Prod (c,t1,t2) when Context.binder_name c == Names.Name.Anonymous ->
+    | Prod (c,t1,t2) when Context.binder_name c == Names.Anonymous ->
              (Node (Impl,(inspect t1),(inspect t2)))
     | Prod (c,t1,t2) when not(dependent sigma (mkRel 1) t2) ->
              (Node (Impl,(inspect t1),(inspect t2)))

--- a/staltac_lib.ml
+++ b/staltac_lib.ml
@@ -7,8 +7,6 @@
 ****************************************************************************
 Implementation of the Stalt tactic *)
 
-open Ltac_plugin
-
 (* The `Stalt' tactic inspired by the Ring tactic *)
 
 (* We have just inserted here the extracted code *)
@@ -1161,7 +1159,7 @@ let convertConcl sigma cl =
     | App (c,[|t1; t2|]) when EConstr.eq_constr sigma c (Lazy.force coq_iff) ->
              (Node (Eq, (inspect t1),(inspect t2)))
 (* Impl *)
-    | Prod (c,t1,t2) when c == Names.Anonymous ->
+    | Prod (c,t1,t2) when Context.binder_name c == Names.Name.Anonymous ->
              (Node (Impl,(inspect t1),(inspect t2)))
     | Prod (c,t1,t2) when not(dependent sigma (mkRel 1) t2) ->
              (Node (Impl,(inspect t1),(inspect t2)))
@@ -1193,7 +1191,7 @@ let convertConcl sigma cl =
 (* Convert the hashtable into a function array *)
 let buildEnv hash =
   let acc = ref (mkApp ((Lazy.force coq_rArrayInitP)
-                ,[| mkLambda (Names.Anonymous, (Lazy.force coq_rNat),
+                ,[| mkLambda (Context.make_annot Names.Anonymous Sorts.Relevant, (Lazy.force coq_rNat),
                    (Lazy.force coq_True)) |])) in
   ConstrMap.iter  (fun c n ->
               acc := (mkApp ((Lazy.force coq_rArraySetP)
@@ -1213,8 +1211,8 @@ let pop_prop_run gl =
            Sort s when (match ESorts.kind sigma s with Sorts.Prop -> true | _ -> false) -> is
          | _            -> get_hyps shyp'
   in
-  let v = (get_hyps (pf_hyps_types gl)) in
-    Proofview.V82.of_tactic (Tacticals.New.tclTHEN (generalize [mkVar v]) (clear [v])) gl
+  let v = Context.binder_name (get_hyps (pf_hyps_types gl)) in
+  Proofview.V82.of_tactic (Tacticals.New.tclTHEN (generalize [mkVar v]) (clear [v])) gl
 
 (* Main function *)
 
@@ -1243,13 +1241,3 @@ let stalt_run gl =
        in
 	 (Proofview.V82.of_tactic (exact_check term)) gl
    | False -> CErrors.user_err (str "StalT can't conclude")
-
-DECLARE PLUGIN "staltac"
-
-TACTIC EXTEND stalt
- [ "stalt" ] -> [ Proofview.V82.tactic stalt_run ]
-END
-
-TACTIC EXTEND pop_prop
- [ "pop_prop" ] -> [ Proofview.V82.tactic pop_prop_run ]
-END

--- a/staltac_plugin.mlpack
+++ b/staltac_plugin.mlpack
@@ -1,0 +1,2 @@
+Staltac_lib
+Staltac


### PR DESCRIPTION
This won't pass the Nix-based CI with scripts generated from the templates, since coq-on-cachix is currently stale (does not include SProp changes). @Zimmi48 do you recommend switching back to regular Coq Nix tarballs in CI, or should we do something else?