### PR TITLE
change maintainer in meta.yml and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A two-level approach to prove tautologies using Stålmarck's algorithm in Coq.
   - Pierre Letouzey (initial)
   - Laurent Théry (initial)
 - Coq-community maintainer(s):
-  - Hugo Herbelin ([**@herbelin**](https://github.com/herbelin))
+  - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU Lesser General Public License v2.1 or later](LICENSE)
 - Compatible Coq versions: Coq master (use the corresponding branch or release for other Coq versions)
 - Additional dependencies: none

--- a/meta.yml
+++ b/meta.yml
@@ -24,8 +24,8 @@ authors:
   initial: true
 
 maintainers:
-- name: Hugo Herbelin
-  nickname: herbelin
+- name: Karl Palmskog
+  nickname: palmskog
 
 license:
   fullname: GNU Lesser General Public License v2.1 or later


### PR DESCRIPTION
This to "formally" change the maintainership according to coq-community/manifesto#104. 

Thanks for your work on this @herbelin, in particular for the recent releases. I'll take it from here, and, e.g., propagate template changes to other branches than `master`.